### PR TITLE
Fix config bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Verbomate
-Generate and run python scripts from your command line.  
+Generate and run python from terminal.
 
 ## Examples
 

--- a/verbomate/main.py
+++ b/verbomate/main.py
@@ -77,8 +77,14 @@ def main():
     parser.add_argument("task", nargs="?", default="", help="Task for the script to perform")
     args = parser.parse_args()
 
+    # Define the path to the config file
+    config_path = os.path.join(os.path.expanduser("~"), ".verbomate", "config.json")
+
     if args.key:
-        with open("config.json", "w") as file:
+        # Ensure the directory for the config file exists
+        os.makedirs(os.path.dirname(config_path), exist_ok=True)
+
+        with open(config_path, "w") as file:
             json.dump({"api_key": args.key}, file)
         print("API key stored.")
         return


### PR DESCRIPTION
config was being stored in the directory `verbomate` was being called in